### PR TITLE
Add Spring Cloud (Dev & POD) profiles

### DIFF
--- a/spaces/profiles/spring-cloud-dev.yaml
+++ b/spaces/profiles/spring-cloud-dev.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: spaces.tanzu.vmware.com/v1alpha1
+kind: Profile
+metadata:
+  name: spring-cloud-dev
+  description: >
+    Configure Application Configuration Service, Service Registry and Spring Cloud Gateway for Kubernetes for Development and Testing. 
+    A Space provisioned with this profile will be able to deploy a stateless Spring app(s), setup internal ingress to reach the app, as well as provide configuration via secrets from a Git repository.
+spec:
+  requiredCapabilities:
+    - name: application-configuration-service.tanzu.vmware.com
+    - name: service-registry.spring.tanzu.vmware.com
+    - name: spring-cloud-gateway.tanzu.vmware.com
+  traits:
+    - name: spring-cloud-dev-trait
+      alias: spring-cloud-dev-trait

--- a/spaces/profiles/spring-cloud-prod.yaml
+++ b/spaces/profiles/spring-cloud-prod.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: spaces.tanzu.vmware.com/v1alpha1
+kind: Profile
+metadata:
+  name: spring-cloud-prod
+  description: >
+    Configure Application Configuration Service, Service Registry and Spring Cloud Gateway for Kubernetes for Production Workflows.
+    A Space provisioned with this profile will be able to deploy a stateless Spring app(s), setup internal ingress to reach the app, as well as provide configuration via secrets from a Git repository.
+spec:
+  requiredCapabilities:
+    - name: application-configuration-service.tanzu.vmware.com
+    - name: service-registry.spring.tanzu.vmware.com
+    - name: spring-cloud-gateway.tanzu.vmware.com
+  traits:
+    - name: spring-cloud-prod-trait
+      alias: spring-cloud-prod-trait

--- a/spaces/traits/spring-cloud-dev-trait.yaml
+++ b/spaces/traits/spring-cloud-dev-trait.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: spaces.tanzu.vmware.com/v1alpha1
+kind: Trait
+metadata:
+  name: spring-cloud-dev-trait
+spec:
+  carvelPackages:
+    - alias: application-configuration-service-installer.tanzu.vmware.com
+      refName: application-configuration-service-installer.tanzu.vmware.com
+      versionSelection:
+        constraints: 1.0.1
+      values:
+        inline:
+          configurationSource:
+            backends:
+            - uri: <https-git-repo-configuration-url>
+    - alias: service-registry-installer.spring.apps.tanzu.vmware.com
+      refName: service-registry-installer.spring.apps.tanzu.vmware.com
+      versionSelection:
+        constraints: 1.0.1
+      values:
+        inline:
+          eurekaServer:
+            replicas: 2
+            imagePullSecretName: <image-pull-secret> # If not provided, can use same as scg
+    - alias: spring-cloud-gateway-installer.tanzu.vmware.com
+      refName: spring-cloud-gateway-installer.tanzu.vmware.com
+      versionSelection:
+        constraints: 1.0.0
+      values:
+        inline:
+          count: 1 # DevMode for development spaces, disables cluster for simpler setup(s)
+          java-opts: "-Dcom.vmware.tanzu.springcloudgateway.dev.mode.enabled=true"
+          env:
+            - name: com.vmware.tanzu.springcloudgateway.no-clustering.enabled # Requires SCG-K8s v2.1.9
+              value: true

--- a/spaces/traits/spring-cloud-prod-trait.yaml
+++ b/spaces/traits/spring-cloud-prod-trait.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: spaces.tanzu.vmware.com/v1alpha1
+kind: Trait
+metadata:
+  name: spring-cloud-prod-trait
+spec:
+  carvelPackages:
+    - alias: application-configuration-service-installer.tanzu.vmware.com
+      refName: application-configuration-service-installer.tanzu.vmware.com
+      versionSelection:
+        constraints: 1.0.1
+      values:
+        inline:
+          configurationSource:
+            backends:
+            - uri: <https-git-repo-configuration-url>
+    - alias: service-registry-installer.spring.apps.tanzu.vmware.com
+      refName: service-registry-installer.spring.apps.tanzu.vmware.com
+      versionSelection:
+        constraints: 1.0.1
+      values:
+        inline:
+          eurekaServer:
+            replicas: 2
+            imagePullSecretName: <image-pull-secret> # If not provided, can use same as SCG
+    - alias: spring-cloud-gateway-installer.tanzu.vmware.com
+      refName: spring-cloud-gateway-installer.tanzu.vmware.com
+      versionSelection:
+        constraints: 1.0.0
+      values:
+        inline:
+          count: 2 # Minimum to test clustering features
+          bindings:
+            redis:
+              secret: <redis-configuration-secret> # Must be provided externally for multi-region setup https://docs.vmware.com/en/VMware-Spring-Cloud-Gateway-for-Kubernetes/2.1/scg-k8s/GUID-guides-redis.html


### PR DESCRIPTION
* Dev: for development and testing only. Runs SCG in dev-mode without clustering/federation features
* Prod: runs SCG for clustering for single and multi-region scenarios. Requires external Redis