### PR TITLE
Updated Profile spring-cloud-dev

### DIFF
--- a/spaces/profiles/spring-cloud-dev.yaml
+++ b/spaces/profiles/spring-cloud-dev.yaml
@@ -20,11 +20,13 @@ spec:
     - name: mtls.tanzu.vmware.com
       alias: mtls.tanzu.vmware.com
     - name: observability-trait
-      alias: observability-trait 
+      alias: observability-trait
     - name: selfsigned-certificate-issuer
-      alias: selfsigned-certificate-issuer      
+      alias: selfsigned-certificate-issuer
+    - name: egress
+      alias: egress
     - name: spring-cloud-gateway
-      alias: spring-cloud-gateway   
+      alias: spring-cloud-gateway
     - name: server-workload
       alias: server-workload
       values:

--- a/spaces/profiles/spring-cloud-dev.yaml
+++ b/spaces/profiles/spring-cloud-dev.yaml
@@ -11,6 +11,29 @@ spec:
     - name: application-configuration-service.tanzu.vmware.com
     - name: service-registry.spring.tanzu.vmware.com
     - name: spring-cloud-gateway.tanzu.vmware.com
+    - name: bitnami.services.tanzu.vmware.com
   traits:
     - name: spring-cloud-dev-trait
       alias: spring-cloud-dev-trait
+    - name: public-ingress
+      alias: public-ingress
+    - name: mtls.tanzu.vmware.com
+      alias: mtls.tanzu.vmware.com
+    - name: observability-trait
+      alias: observability-trait 
+    - name: selfsigned-certificate-issuer
+      alias: selfsigned-certificate-issuer      
+    - name: spring-cloud-gateway
+      alias: spring-cloud-gateway   
+    - name: server-workload
+      alias: server-workload
+      values:
+        inline:
+          server-workload-installer.tanzu.vmware.com:
+            #! Service account name to be created and granted permissions, associating it with RBAC rules for server workloads.
+            serviceAccountName: server-workload-installer
+          workload-imagepull-secret.tanzu.vmware.com:
+            #! name of ImagePullSecret to be associated with workload serviceAccount.
+            secretName: workload-imagepull-secret
+            #! Service account used for running the workload.
+            serviceAccountName: default          


### PR DESCRIPTION
Added the following Traits to the spring-cloud-dev Profile: 

1. public-ingress
2. mtls.tanzu.vmware.com
3. observability-trait
4. selfsigned-certificate-issuer
5. egress
6. spring-cloud-gateway
7. server-workload 