### PR TITLE
Bump spring-cloud-gateway-installer.tanzu.vmware.com to v1.0.1

### DIFF
--- a/spaces/traits/spring-cloud-gateway.yaml
+++ b/spaces/traits/spring-cloud-gateway.yaml
@@ -9,4 +9,4 @@ spec:
     - alias: spring-cloud-gateway-installer.tanzu.vmware.com
       refName: spring-cloud-gateway-installer.tanzu.vmware.com
       versionSelection:
-        constraints: 1.0.0
+        constraints: 1.0.1


### PR DESCRIPTION
This version includes 'resources' element to configure cpu and memory for Beta 3.

[COSMOS-9025](https://jira.eng.vmware.com/browse/COSMOS-9025)